### PR TITLE
run all powershell commands with -ExecutionPolicy Bypass to avoid failures on a fresh OS thats non 2012R2

### DIFF
--- a/lib/busser/runner_plugin/pester.rb
+++ b/lib/busser/runner_plugin/pester.rb
@@ -19,16 +19,16 @@ require 'busser/runner_plugin'
 class Busser::RunnerPlugin::Pester < Busser::RunnerPlugin::Base
   postinstall do
     banner "[pester] Installing PsGet"
-    run!("powershell.exe -NonInteractive -NoProfile -Command \"iex (new-object Net.WebClient).DownloadString('http://bit.ly/GetPsGet')\"")
+    run!("powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -Command \"iex (new-object Net.WebClient).DownloadString('http://bit.ly/GetPsGet')\"")
     banner "[pester] Installing Pester"
-    run!("powershell.exe -NonInteractive -NoProfile -Command \"Import-Module PsGet; Install-Module Pester\"")
+    run!("powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -Command \"Import-Module PsGet; Install-Module Pester\"")
   end
 
   def test
     banner "[pester] Running"
     pester_path = suite_path('pester').to_s
     Dir.chdir(pester_path) do
-      run!("powershell.exe -NonInteractive -NoProfile -Command \"Import-Module Pester; Invoke-Pester -EnableExit\"")
+      run!("powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -Command \"Import-Module Pester; Invoke-Pester -EnableExit\"")
     end
   end
 end


### PR DESCRIPTION
Ran into this running on win 8.1

Unless a user has already explicitly set the powershell Execution policy on the machine to atleast RemoteSigned, the busser setup will fail on all OSs other than 2012R2 which has a default ExecutionPolicy of RemoteSigned.

This can be avoided by starting powershell.exe with `-ExecutionPolicy Bypass` which bypasses the policy rules.

I have also filed an issue against the dsc cookbook with the same problem.

Both can be worked around if the cookbook has:

```
powershell_script "set execution policy" do
  code <<-EOH
    Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force
    if(Test-Path "$env:SystemRoot\\SysWOW64") {
      Start-Process "$env:SystemRoot\\SysWOW64\\WindowsPowerShell\\v1.0\\powershell.exe" -verb runas -wait -argumentList "-noprofile -WindowStyle hidden -noninteractive -ExecutionPolicy bypass -Command `"Set-ExecutionPolicy RemoteSigned`""
    }
    EOH
end
```

Which sets the execution policy for both 64 and 32 bit shells. Need the 32 bit shell set since chef-client is 32 bit.
