### PR TITLE
Check for local installs of Pester first

### DIFF
--- a/lib/busser/pester/version.rb
+++ b/lib/busser/pester/version.rb
@@ -1,5 +1,5 @@
 module Busser
   module Pester
-    VERSION = "0.0.7"
+    VERSION = "0.0.8"
   end
 end

--- a/lib/busser/runner_plugin/pester.rb
+++ b/lib/busser/runner_plugin/pester.rb
@@ -20,12 +20,12 @@ class Busser::RunnerPlugin::Pester < Busser::RunnerPlugin::Base
   postinstall do
     banner "[pester] Installing PsGet"
     download_psget = <<-DOWNLOADPSGET 
-      powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -Command "if (-not get-module -list pester) {iex (new-object Net.WebClient).DownloadString('http://bit.ly/GetPsGet')}"
+      c:\\windows\\sysnative\\windowspowershell\\v1.0\\powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -Command "if (-not get-module -list pester) {iex (new-object Net.WebClient).DownloadString('http://bit.ly/GetPsGet')}"
     DOWNLOADPSGET
     run!(download_psget)
     banner "[pester] Installing Pester"
     download_pester = <<-DOWNLOADPESTER 
-      powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -Command "if (-not get-module -list pester) {Import-Module PsGet; Install-Module Pester}"
+      c:\\windows\\sysnative\\windowspowershell\\v1.0\\powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -Command "if (-not get-module -list pester) {Import-Module PsGet; Install-Module Pester}"
     DOWNLOADPESTER
     run!(download_pester)
   end
@@ -34,7 +34,7 @@ class Busser::RunnerPlugin::Pester < Busser::RunnerPlugin::Base
     banner "[pester] Running"
     pester_path = suite_path('pester').to_s
     Dir.chdir(pester_path) do
-      run!("powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -Command \"Import-Module Pester; write-host ''; Invoke-Pester -EnableExit\"")
+      run!("c:\\windows\\sysnative\\windowspowershell\\v1.0\\powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -Command \"Import-Module Pester; write-host ''; Invoke-Pester -EnableExit\"")
     end
   end
 end


### PR DESCRIPTION
When testing locally, we should check if the module is there rather than pulling down Pester every time.  I've added a check to see if Pester is found on the system before installing PSGet and before installing Pester.  There is a bit of duplication and it could be made less ugly, but it works now.

I've also added a blank line in between the logging message from Test-Kitchen and the start of the Pester run.
